### PR TITLE
fix(flake): use `jetbrains-rofi-next` in both `flake.apps`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
               };
               rofi = {
                 type = "app";
-                program = "${mkRofiPackage pkgs.rofi packages.rofi-jetbrains}/bin/rofi";
+                program = "${mkRofiPackage pkgs.rofi packages.rofi-jetbrains-next}/bin/rofi";
                 meta.description = "rofi cli with the `rofi-jetbrains` plugin pre-installed";
               };
             };


### PR DESCRIPTION
Since newest `nixpkgs` now includes an updated rofi version which requires abi v7