### PR TITLE
feat!: add support for `direnv`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "direnv"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691d98072428846b881361c9afae2867f082ae7122b068daf3e5c9eebdc61802"
+dependencies = [
+ "cfg-if",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "thiserror",
+ "which",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +240,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "futures-channel"
@@ -401,6 +426,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,9 +519,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
@@ -498,6 +532,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
@@ -701,6 +741,7 @@ version = "2.2.1"
 dependencies = [
  "amxml",
  "chrono",
+ "direnv",
  "dirs 5.0.1",
  "glib",
  "itertools 0.12.1",
@@ -742,6 +783,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -803,6 +866,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1043,6 +1117,18 @@ dependencies = [
  "regex",
  "thiserror",
  "walkdir",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ strip = true
 [dependencies]
 amxml = "0.5.3"
 chrono = "0.4.31"
+direnv = "0.1.1"
 dirs = "5.0.1"
 glib = { version = "0.19.6", features = ["log_macros"] }
 itertools = "0.12.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ static ROFI_CONFIG_PREFIX: &str = "jetbrains-";
 pub struct Config {
   pub install_dir: PathBuf,
   pub custom_aliases: Vec<(String, IDEType)>,
-  pub use_clion_devshell: bool,
+  pub use_direnv: bool,
 }
 
 impl Config {
@@ -31,10 +31,25 @@ impl Config {
     )
     .unwrap_or_default();
 
-    let use_clion_devshell = config_parse_option::<bool>(
-      &(ROFI_CONFIG_PREFIX.to_owned() + "use-clion-devshell"),
-      "Whether to use the nix devshell when opening a CLion project",
-    );
+    let use_direnv = {
+      let clion_devshell = config_parse_option::<bool>(
+        &(ROFI_CONFIG_PREFIX.to_owned() + "use-clion-devshell"),
+        r#"
+      Deprecated: use 'use-direnv' option instead.
+      Whether to use a nix devshell when opening a CLion project
+      "#,
+      );
+
+      if clion_devshell {
+        warn!("'use-clion-devshell' option is deprecated, use 'use-direnv' instead.");
+        clion_devshell
+      } else {
+        config_parse_option::<bool>(
+          &(ROFI_CONFIG_PREFIX.to_owned() + "use-direnv"),
+          "Whether to enter a direnv shell before opening a project",
+        )
+      }
+    };
 
     let custom_aliases = custom_aliases
       .into_iter()
@@ -70,7 +85,7 @@ impl Config {
           .to_path_buf()
       }),
       custom_aliases,
-      use_clion_devshell,
+      use_direnv,
     }
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,13 +35,13 @@ impl Config {
       let clion_devshell = config_parse_option::<bool>(
         &(ROFI_CONFIG_PREFIX.to_owned() + "use-clion-devshell"),
         r#"
-      Deprecated: use 'use-direnv' option instead.
+      Deprecated: use the 'jetbrains-use-direnv' option instead.
       Whether to use a nix devshell when opening a CLion project
       "#,
       );
 
       if clion_devshell {
-        warn!("'use-clion-devshell' option is deprecated, use 'use-direnv' instead.");
+        warn!("'jetbrains-use-clion-devshell' option is deprecated, use 'jetbrains-use-direnv' option instead.");
         clion_devshell
       } else {
         config_parse_option::<bool>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-use direnv::AllowedStatus;
-use glib::{debug, error, warn, GlibLogger, GlibLoggerDomain, GlibLoggerFormat};
+use glib::{debug, warn, GlibLogger, GlibLoggerDomain, GlibLoggerFormat};
 use itertools::Itertools;
 use log::LevelFilter;
 use rayon::prelude::*;
@@ -9,7 +8,7 @@ use rofi_mode::{export_mode, Action, Api, Event, Matcher};
 use std::collections::HashMap;
 use std::os::unix::process::CommandExt;
 use std::process;
-use std::process::{exit, Command};
+use std::process::Command;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 use wax::{Glob, LinkBehavior, WalkEntry};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use crate::ide::properties::IDEProperties;
 use crate::ide::IDEType;
 use crate::macros::wrap_icon_request;
 use crate::recent_project::{RecentProject, RecentProjectsParser};
-use crate::traits::{MapToErrorLog, MapToErrorLogAndExit};
+use crate::traits::{MapToErrorLog, MapToErrorLogAndExit, ToErrorLogAndExit};
 
 mod config;
 mod ide;
@@ -249,10 +249,8 @@ impl<'rofi> rofi_mode::Mode<'rofi> for Mode<'rofi> {
 
             let state = direnv
               .status(&project.path)
-              .map_to_error_log_and_exit(
-                "Unsupported direnv version, please upgrade to v2.33.0 or newer",
-              )
-              .state;
+              .map(|v| v.state)
+              .to_error_log_and_exit();
 
             (direnv.bin_path, state.is_allowed())
           };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,16 @@
-use std::collections::HashMap;
-use std::os::unix::process::CommandExt;
-use std::process;
-use std::process::Command;
-use std::sync::Arc;
-
-use glib::{debug, warn, GlibLogger, GlibLoggerDomain, GlibLoggerFormat};
+use direnv::AllowedStatus;
+use glib::{debug, error, warn, GlibLogger, GlibLoggerDomain, GlibLoggerFormat};
 use itertools::Itertools;
 use log::LevelFilter;
 use rayon::prelude::*;
 use resolve_path::PathResolveExt;
 use rofi_mode::cairo::Surface;
 use rofi_mode::{export_mode, Action, Api, Event, Matcher};
+use std::collections::HashMap;
+use std::os::unix::process::CommandExt;
+use std::process;
+use std::process::{exit, Command};
+use std::sync::Arc;
 use strum::IntoEnumIterator;
 use wax::{Glob, LinkBehavior, WalkEntry};
 
@@ -21,7 +21,7 @@ use crate::ide::properties::IDEProperties;
 use crate::ide::IDEType;
 use crate::macros::wrap_icon_request;
 use crate::recent_project::{RecentProject, RecentProjectsParser};
-use crate::traits::MapToErrorLog;
+use crate::traits::{MapToErrorLog, MapToErrorLogAndExit};
 
 mod config;
 mod ide;
@@ -239,22 +239,44 @@ impl<'rofi> rofi_mode::Mode<'rofi> for Mode<'rofi> {
     match event {
       Event::Ok { selected, .. } => {
         let project = &self.entries[selected];
-        let use_nix_devshell =
-          project.ide.ide_type == IDEType::CLion && self.config.use_clion_devshell;
-        let cmd = if use_nix_devshell {
-          "nix"
+        let default_cmd = project.ide.launcher_path.to_string_lossy().into_owned();
+        let default_args = vec![project.path.to_string_lossy().into_owned()];
+
+        let (cmd, args) = if self.config.use_direnv {
+          // value returned by this can be `true` only if `rc` is found and allowed.
+          let (direnv, rc_found) = {
+            let direnv = direnv::DirenvInstall::detect()
+              .map_to_error_log_and_exit("Could not find direnv installed on the system");
+
+            let state = direnv
+              .status(&project.path)
+              .map_to_error_log_and_exit(
+                "Unsupported direnv version, please upgrade to v2.33.0 or newer",
+              )
+              .state;
+
+            (direnv.bin_path, state.is_allowed())
+          };
+
+          if rc_found {
+            let project_path = project.path.to_string_lossy().into_owned();
+            let ide_path = project.ide.launcher_path.to_string_lossy().into_owned();
+
+            (
+              direnv.to_string_lossy().into_owned(),
+              vec![
+                "exec".to_string(),
+                project_path.clone(),
+                ide_path,
+                project_path,
+              ],
+            )
+          } else {
+            warn!("direnv rc was not found or was not allowed to execute, falling back to default");
+            (default_cmd, default_args)
+          }
         } else {
-          &project.ide.launcher_path.to_string_lossy()
-        };
-        let args = if use_nix_devshell {
-          vec![
-            "develop".to_string(),
-            "-c".to_string(),
-            project.ide.launcher_path.to_string_lossy().into_owned(),
-            project.path.to_string_lossy().into_owned(),
-          ]
-        } else {
-          vec![project.path.to_string_lossy().into_owned()]
+          (default_cmd, default_args)
         };
 
         let mut cmd = Command::new(cmd);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,6 @@
-use std::borrow::Cow;
-
 use glib::error;
+use std::borrow::Cow;
+use std::process::exit;
 
 use crate::G_LOG_DOMAIN;
 
@@ -43,6 +43,34 @@ impl<T, E> MapToErrorLog<T> for Result<T, E> {
       Err(_) => {
         error!("{}", msg.as_ref());
         Err(())
+      }
+    }
+  }
+}
+
+pub trait MapToErrorLogAndExit<T> {
+  fn map_to_error_log_and_exit<M: AsRef<str>>(self, msg: M) -> T;
+}
+
+impl<T> MapToErrorLogAndExit<T> for Option<T> {
+  fn map_to_error_log_and_exit<M: AsRef<str>>(self, msg: M) -> T {
+    match self {
+      Some(v) => v,
+      None => {
+        error!("{}", msg.as_ref());
+        exit(1)
+      }
+    }
+  }
+}
+
+impl<T, E> MapToErrorLogAndExit<T> for Result<T, E> {
+  fn map_to_error_log_and_exit<M: AsRef<str>>(self, msg: M) -> T {
+    match self {
+      Ok(v) => v,
+      Err(_) => {
+        error!("{}", msg.as_ref());
+        exit(1)
       }
     }
   }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,6 @@
 use glib::error;
 use std::borrow::Cow;
+use std::fmt::Display;
 use std::process::exit;
 
 use crate::G_LOG_DOMAIN;
@@ -73,5 +74,21 @@ impl<T, E> MapToErrorLogAndExit<T> for Result<T, E> {
         exit(1)
       }
     }
+  }
+}
+
+pub trait ToErrorLogAndExit<T, E> {
+  fn to_error_log_and_exit(self) -> T;
+}
+
+impl<T, E> ToErrorLogAndExit<T, E> for Result<T, E>
+where
+  E: Display,
+{
+  fn to_error_log_and_exit(self) -> T {
+    self.unwrap_or_else(|err| {
+      error!("{}", err);
+      exit(1)
+    })
   }
 }

--- a/test.rasi
+++ b/test.rasi
@@ -3,5 +3,5 @@ configuration {
     show-icons: true;
     jetbrains-custom-aliases: ["web:WS", "cpp:CL"];
     jetbrains-install-dir: "~/.local/share/JetBrains/Toolbox/apps/";
-    jetbrains-use-clion-devshell: true;
+    jetbrains-use-direnv: true;
 }


### PR DESCRIPTION
This adds support for entering `direnv` shell before opening the project.  
It also deprecates the `jetbrains-use-clion-devshell` option.